### PR TITLE
Deprecate is_native in PaymentMethod

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@ mod tests {
             .new_invoice(
                 U256::from_str("0").unwrap(),
                 PaymentMethod {
-                    is_native: true,
                     token_address: None,
                 },
                 bincode::serialize("test").unwrap(),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -19,8 +19,6 @@ pub trait Serializable {
 /// a gateway
 #[derive(Clone, Deserialize, Serialize)]
 pub struct PaymentMethod {
-    /// Whether or not the method uses native gas token
-    pub is_native: bool,
     /// The address of the ERC20 token
     pub token_address: Option<String>,
 }


### PR DESCRIPTION
We do not need it since we can rely on the Option<> of token address to check if we should use native or ERC20 payment