### PR TITLE
Add invoice id when returning

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -174,7 +174,7 @@ impl PaymentGateway {
         method: PaymentMethod,
         message: Vec<u8>,
         expires_in_seconds: u64,
-    ) -> Result<Invoice, DatabaseError> {
+    ) -> Result<(String,Invoice), DatabaseError> {
         // Generate random wallet
         let signer = LocalWallet::new(&mut ethers::core::rand::thread_rng());
         let invoice = Invoice {
@@ -195,6 +195,6 @@ impl PaymentGateway {
         let invoice_id = hash_now(seed);
         // Save the invoice in db.
         set(&self.tree, &invoice_id, &invoice).await?;
-        Ok(invoice)
+        Ok((invoice_id,invoice))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ mod tests {
         }
     }
 
-    async fn insert_test_invoice(gateway: &PaymentGateway) -> Result<Invoice, DatabaseError> {
+    async fn insert_test_invoice(gateway: &PaymentGateway) -> Result<(String,Invoice), DatabaseError> {
         gateway
             .new_invoice(
                 U256::from_str("0").unwrap(),
@@ -67,7 +67,7 @@ mod tests {
     async fn assert_valid_address_length() {
         let gateway = setup_test_gateway("./test-assert-valid-address-length");
         let invoice = insert_test_invoice(&gateway).await.unwrap();
-        let address=format!("{:?}", invoice.to);
+        let address=format!("{:?}", invoice.1.to);
         let address_length = address.len();
         println!("Address: {}", address);
         println!("Address length: {}", address_length);


### PR DESCRIPTION
When creating an invoice, its id should be returned that was used to store it in the database.